### PR TITLE
Define __STDC_FORMAT_MACROS for build with older glibc

### DIFF
--- a/src/build_filter.cpp
+++ b/src/build_filter.cpp
@@ -1,3 +1,4 @@
+#define __STDC_FORMAT_MACROS
 #define _GNU_SOURCE
 #include <getopt.h>
 #include <inttypes.h>

--- a/src/query_filter.cpp
+++ b/src/query_filter.cpp
@@ -1,3 +1,4 @@
+#define __STDC_FORMAT_MACROS
 #include "hexutil.h"
 #include "mappeablebloomfilter.h"
 #include "sha.h"


### PR DESCRIPTION
Fix build on systems that have sufficiently recent g++ (e.g., with Red Hat devtoolsets), but older glibc (e.g., RHEL6 and RHEL7). The same underlying issue is reasonably described here: https://github.com/dyninst/dyninst/issues/626