### PR TITLE
Fix build after dependencies update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ dependencies/xor_singleheader/include/xorfilter.h:
 query_filter: src/query_filter.cpp src/hexutil.h          dependencies/xor_singleheader/include/xorfilter.h
 	c++ -O3 -o query_filter src/query_filter.cpp -Wall -std=c++11 -Idependencies/fastfilter_cpp/src  -Idependencies
 
-build_filter: src/build_filter.cpp dependencies/fastfilter_cpp/src/xorfilter.h dependencies/fastfilter_cpp/src/xorfilter_plus.h src/hexutil.h             dependencies/xor_singleheader/include/xorfilter.h
+build_filter: src/build_filter.cpp dependencies/fastfilter_cpp/src/xorfilter/xorfilter.h dependencies/fastfilter_cpp/src/xorfilter/xorfilter_plus.h src/hexutil.h             dependencies/xor_singleheader/include/xorfilter.h
 	c++ -O3 -o build_filter src/build_filter.cpp -std=c++11 -Wall -Idependencies/fastfilter_cpp/src -Idependencies
 
 clean:


### PR DESCRIPTION
Commit 1ba514e2407e08ab6e0b2261b526c60fbec4629a updated the expected git dependencies, but missed a corresponding update of header file dependencies in the `Makefile`. Fix that.